### PR TITLE
TH-fonts: bump TH-Ming and TH-Tshyn to 5.0.0

### DIFF
--- a/packages/TH-fonts/Ming.nix
+++ b/packages/TH-fonts/Ming.nix
@@ -19,11 +19,11 @@ let
     url = "http://cheonhyeong.com/Simplified/download.html";
   };
 
-  version = "4.1.0";
+  version = "5.0.0";
 
   src = fetchurl {
     url = "http://cheonhyeong.com/File/TH-Ming-${version}.7z";
-    hash = "sha256-HzDbcEnljEY7Iji/ilvdlH92bglrw97N1JZwcD08Yw0=";
+    hash = "sha256-cGX7yIjZIaf4ivIGFweyrEtXpvCyjoM0NM9ra9RY6N0=";
   };
 
   meta = {

--- a/packages/TH-fonts/Tshyn.nix
+++ b/packages/TH-fonts/Tshyn.nix
@@ -19,11 +19,11 @@ let
     url = "http://cheonhyeong.com/Simplified/download.html";
   };
 
-  version = "4.1.0";
+  version = "5.0.0";
 
   src = fetchurl {
     url = "http://cheonhyeong.com/File/TH-Tshyn-${version}.7z";
-    hash = "sha256-QqDKNGOnrtFK1p5JdoVLQr+PoZr9TvsVICvMxqSxdyA=";
+    hash = "sha256-cqYgRfj3busbxVuQbKYdD+jcx3mDkfUrtFgQDpEdazM=";
   };
 
   meta = {


### PR DESCRIPTION
Upstream cheonhyeong.com replaced the 4.1.0 archives in-place with 5.0.0,
so the pinned sha256 in `packages/TH-fonts/{Ming,Tshyn}.nix` no longer
matches and `nix build .#TH-fonts` (or any consumer pulling `THFonts.*`)
fails with a fixed-output hash mismatch. This bumps both to 5.0.0 with
the new hashes:

- `TH-Ming-5.0.0.7z` → `sha256-cGX7yIjZIaf4ivIGFweyrEtXpvCyjoM0NM9ra9RY6N0=`
- `TH-Tshyn-5.0.0.7z` → `sha256-cqYgRfj3busbxVuQbKYdD+jcx3mDkfUrtFgQDpEdazM=`

Other TH-fonts (Hak, Joeng, Khaai-{P,T}, Sung-{P,T}, Sy) still build
unchanged with their 4.0.0 / 4.1.0 pins.