### PR TITLE
packages: rename xorg.lndir -> lndir

### DIFF
--- a/packages/TH-fonts/package.nix
+++ b/packages/TH-fonts/package.nix
@@ -2,7 +2,7 @@
   lib,
   newScope,
   stdenvNoCC,
-  xorg,
+  lndir,
   ...
 }:
 let
@@ -44,7 +44,7 @@ makeScope newScope (
         version = "0-unstable";
 
         buildInputs = [
-          xorg.lndir
+          lndir
         ] ++ drvs;
 
         unpackPhase = "true";
@@ -54,7 +54,7 @@ makeScope newScope (
 
           mkdir -p $out
           for drv in ${concatStringsSep " " drvs}; do
-            ${xorg.lndir}/bin/lndir -silent $drv $out
+            ${lndir}/bin/lndir -silent $drv $out
           done
 
           runHook postInstall

--- a/packages/alibaba-fonts/package.nix
+++ b/packages/alibaba-fonts/package.nix
@@ -2,7 +2,7 @@
   lib,
   newScope,
   stdenvNoCC,
-  xorg,
+  lndir,
   ...
 }:
 let
@@ -38,7 +38,7 @@ makeScope newScope (
         version = "0-unstable";
 
         buildInputs = [
-          xorg.lndir
+          lndir
         ] ++ drvs;
 
         unpackPhase = "true";
@@ -48,7 +48,7 @@ makeScope newScope (
 
           mkdir -p $out
           for drv in ${concatStringsSep " " drvs}; do
-            ${xorg.lndir}/bin/lndir -silent $drv $out
+            ${lndir}/bin/lndir -silent $drv $out
           done
 
           runHook postInstall

--- a/packages/foundertype-fonts/package.nix
+++ b/packages/foundertype-fonts/package.nix
@@ -3,7 +3,7 @@
   lib,
   newScope,
   stdenvNoCC,
-  xorg,
+  lndir,
   ...
 }:
 let
@@ -113,7 +113,7 @@ makeScope newScope (
         version = "0-unstable";
 
         buildInputs = [
-          xorg.lndir
+          lndir
         ] ++ drvs;
 
         unpackPhase = "true";
@@ -123,7 +123,7 @@ makeScope newScope (
 
           mkdir -p $out
           for drv in ${concatStringsSep " " drvs}; do
-            ${xorg.lndir}/bin/lndir -silent $drv $out
+            ${lndir}/bin/lndir -silent $drv $out
           done
 
           runHook postInstall

--- a/packages/trionestype-fonts/package.nix
+++ b/packages/trionestype-fonts/package.nix
@@ -2,7 +2,7 @@
   lib,
   newScope,
   stdenvNoCC,
-  xorg,
+  lndir,
   ...
 }:
 let
@@ -36,7 +36,7 @@ makeScope newScope (
         version = "0-unstable";
 
         buildInputs = [
-          xorg.lndir
+          lndir
         ] ++ drvs;
 
         unpackPhase = "true";
@@ -46,7 +46,7 @@ makeScope newScope (
 
           mkdir -p $out
           for drv in ${concatStringsSep " " drvs}; do
-            ${xorg.lndir}/bin/lndir -silent $drv $out
+            ${lndir}/bin/lndir -silent $drv $out
           done
 
           runHook postInstall

--- a/packages/tsangertype-fonts/package.nix
+++ b/packages/tsangertype-fonts/package.nix
@@ -3,7 +3,7 @@
   lib,
   newScope,
   stdenvNoCC,
-  xorg,
+  lndir,
   ...
 }:
 let
@@ -124,7 +124,7 @@ makeScope newScope (
         version = "0-unstable";
 
         buildInputs = [
-          xorg.lndir
+          lndir
         ] ++ drvs;
 
         unpackPhase = "true";
@@ -134,7 +134,7 @@ makeScope newScope (
 
           mkdir -p $out
           for drv in ${concatStringsSep " " drvs}; do
-            ${xorg.lndir}/bin/lndir -silent $drv $out
+            ${lndir}/bin/lndir -silent $drv $out
           done
 
           runHook postInstall


### PR DESCRIPTION
nixpkgs deprecated the \`xorg\` attribute set; \`lndir\` is now a top-level
attribute. Renaming the function arg + call sites silences the warnings:

\`\`\`
evaluation warning: The xorg package set has been deprecated, 'xorg.lndir' has been renamed to 'lndir'
\`\`\`

Affects all 5 \`combine'\`-style font packages (TH-fonts, alibaba-fonts,
foundertype-fonts, trionestype-fonts, tsangertype-fonts).